### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go run cmd/hargo/hargo.go validate test/golang.org.har
 
 ## Building from source
 
-Make sure that you have Go version 1.7 or greater (I haven't tested with lower) and that your `GOPATH` env variable is set (I recommand setting it to `~/go` if you don't have one). If `GOBIN` is not set, also try setting that to `~/go/bin`, as `make install` may fail. You can check all Go environment variables with `go env`.
+Make sure that you have Go version 1.7 or greater (I haven't tested with lower) and that your `GOPATH` env variable is set (I recommend setting it to `~/go` if you don't have one). If `GOBIN` is not set, also try setting that to `~/go/bin`, as `make install` may fail. You can check all Go environment variables with `go env`.
 
 ```text
 go get -d github.com/mrichman/hargo


### PR DESCRIPTION
## Summary
- fix a typo in the README

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842fc351d28832d9f3037dd28c3195c